### PR TITLE
fix: workaround for async loading issues with page titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-gdpr-tracking",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,5 +1,6 @@
 import Cookies from "js-cookie"
 
+const timeoutLength = 32; //https://github.com/gatsbyjs/gatsby/commit/42f509eadb06753f7b529f3682f22e012c21dc9b#diff-bf0d94c8bf47d5c1687e342c2dba1e00R31
 const currentEnvironment = process.env.ENV || process.env.NODE_ENV || "development";
 
 const defaultOptions = {
@@ -97,11 +98,11 @@ export const onRouteUpdate = ({location}, {environments = defaultOptions.environ
       if (debug) {
         console.log(`onRouteUpdate - inside trackGoogleAnalytics - track page view for path: `, location.pathname);
       }
-      gtag('config', googleAnalyticsOpt.trackingId, {
+      setTimeout(gtag('config', googleAnalyticsOpt.trackingId, {
         'anonymize_ip': googleAnalyticsOpt.anonymize.toString(),
         'page_path': location.pathname,
         'cookie_flags': googleAnalyticsOpt.cookieFlags
-      });
+      }), 50);
     } else {
       if (debug) {
         console.log(`onRouteUpdate - inside trackGoogleAnalytics function - tracking is disabled!!`);
@@ -145,7 +146,9 @@ export const onRouteUpdate = ({location}, {environments = defaultOptions.environ
   if (debug) {
     console.log(`onRouteUpdate - call tracking functions`);
   }
-  window.trackGoogleAnalytics();
-  window.trackGoogleAds();
-
+  //setTimeout workaround to try to ensure the page title loads
+  setTimeout(() => {
+    window.trackGoogleAnalytics();
+    window.trackGoogleAds();
+  }, timeoutLength);
 };

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -98,11 +98,11 @@ export const onRouteUpdate = ({location}, {environments = defaultOptions.environ
       if (debug) {
         console.log(`onRouteUpdate - inside trackGoogleAnalytics - track page view for path: `, location.pathname);
       }
-      setTimeout(gtag('config', googleAnalyticsOpt.trackingId, {
+      gtag('config', googleAnalyticsOpt.trackingId, {
         'anonymize_ip': googleAnalyticsOpt.anonymize.toString(),
         'page_path': location.pathname,
         'cookie_flags': googleAnalyticsOpt.cookieFlags
-      }), 50);
+      });
     } else {
       if (debug) {
         console.log(`onRouteUpdate - inside trackGoogleAnalytics function - tracking is disabled!!`);


### PR DESCRIPTION
The current plugin faces the same challenge as many gatsby GA plugins. The async calls for the SEO params (Helmet, etc.) don't necessarily complete ahead of the GA calls. the settimeout is a hack to be sure, but it appears to be the best we can do presently.